### PR TITLE
Remove version string format on checkDockerversion

### DIFF
--- a/OracleRestDataServices/dockerfiles/buildContainerImage.sh
+++ b/OracleRestDataServices/dockerfiles/buildContainerImage.sh
@@ -80,7 +80,7 @@ checkPodmanVersion() {
 checkDockerVersion() {
   # Get Docker Server version
   echo "Checking Docker version."
-  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version | printf "%.5s" }}'|| exit 0)
+  DOCKER_VERSION=$("${CONTAINER_RUNTIME}" version --format '{{.Server.Version }}'|| exit 0)
   # Remove dot in Docker version
   DOCKER_VERSION=${DOCKER_VERSION//./}
 


### PR DESCRIPTION
The printf formatting strips away the last digit of the version number resulting in a 3 digit number instead of a 4 digit number.

This causes the version checker to fail as 1709 is not less than 240 eg. minimum version: 17.0.9 vs my install version: 24.0.5.